### PR TITLE
Tweaks to work with coq 8.11.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@
 ##Coq
 *.vo
 *.glob
+*.d
 *.v.d
+*.vos
+*.vok
 *~
 Makefile.coq
 Makefile.coq.conf

--- a/MLTT2/FibReplInconsistent.v
+++ b/MLTT2/FibReplInconsistent.v
@@ -25,6 +25,8 @@ Module Export FibrantReplacement.
   Defined.
 End FibrantReplacement.
 
+Global Existing Instance Fibrant_repl.
+
 Definition recR {X P} {FibP: Fibrant P} (H: X -> P)
   : repl X -> P
   := elimR (λ _ : repl X, P) H.

--- a/MLTT2/Overture.v
+++ b/MLTT2/Overture.v
@@ -3,6 +3,7 @@ Require Export TLTT.Overture.
 Axiom Fibrant : Type -> Type.
 Existing Class Fibrant.
 
+Declare Scope Fib_scope.
 Notation "'FibrantF' P" := (forall x, Fibrant (P x)) (at level 10) : Fib_scope.
 Notation "'FibrantF2' P" := (forall x y, Fibrant (P x y)) (at level 10) : Fib_scope.
 Open Scope Fib_scope.
@@ -21,14 +22,19 @@ Global Existing Instance TypeF_F.
 Axiom Fibrant_forall
   : forall A (B: A -> Type), Fibrant A -> (forall x, Fibrant (B x)) -> Fibrant (forall x, B x).
 
+Global Existing Instance Fibrant_forall.
+
 Axiom Fibrant_sigma
   : forall A (B: A -> Type), Fibrant A -> (forall x, Fibrant (B x)) -> Fibrant (sigT B).
+
+Global Existing Instance Fibrant_sigma.
 
 (* Axiom Fibrant_Type : Fibrant Type. *)
 
 (* Axiom Fibrant_TypeF : Fibrant FType. *)
 
 Axiom Fibrant_unit : Fibrant unit.
+Global Existing Instance Fibrant_unit.
 
 Module Export Paths.
   Private Inductive paths {A : Type} (a : A) : A -> Type :=
@@ -52,7 +58,7 @@ Module Export Paths.
     end.
     
   Axiom Fibrant_paths : forall (A: Type) {FibA: Fibrant A} (x y: A), Fibrant (paths x y).
-
+  Existing Instance Fibrant_paths.
   
   (** The inverse of a path. *)
   Definition inverse {A : Type} {FibA: Fibrant A} {x y : A} (p : paths x y) : paths y x
@@ -70,6 +76,8 @@ Module Export Paths.
   (* Hence this plugin forces Coq to use paths_rec and paths_rec' instead. *)
   Declare ML Module "myrewrite".
 End Paths.
+
+Global Existing Instance Fibrant_paths.
 
 Arguments paths_rec [A _] a P [_] f y p.
 
@@ -109,6 +117,7 @@ Defined.
 
 Arguments concat {A FibA x y z} !p !q.
 
+Declare Scope path_scope.
 Delimit Scope path_scope with path.
 Open Scope path_scope.
 

--- a/MLTT2F/Fibrant_replacement.v
+++ b/MLTT2F/Fibrant_replacement.v
@@ -9,6 +9,7 @@ Module Export FibrantReplacement.
   Arguments η {_} _.
   
   Axiom Fibrant_repl : forall X, Fibrant (repl X).
+  Global Existing Instance Fibrant_repl.
   
   Definition repl_ind {X} (P: repl X -> Type) {FibP: FibrantF P}
              (H: forall x : X, P (η x))
@@ -25,6 +26,7 @@ Definition repl_rec {X P} {FibP: Fibrant P} (H: X -> P)
 
 Axiom FibrantF_repl_rec : ∀ A (P: A -> Type) {FibP: FibrantF P},
     FibrantF (repl_rec P).
+Global Existing Instance FibrantF_repl_rec.
   
 Definition repl_sigma {A} (B: repl A -> Type) {FibB: FibrantF B}
   : sigT B -> repl (sigT (B o η)).

--- a/MLTT2F/Overture.v
+++ b/MLTT2F/Overture.v
@@ -5,6 +5,7 @@ Require Export TLTT.Overture.
 Axiom FibrantF : forall {A: Type} (P: A -> Type), Type.
 Existing Class FibrantF.
 
+Declare Scope Fib_scope.
 Notation "'Fibrant' A" := (FibrantF (λ _:unit, A)) (at level 10) : Fib_scope.
 Notation "'FibrantF2' P" := (FibrantF (λ w, P w.1 w.2)) (at level 10) : Fib_scope.
 Notation "'FibrantF3' P" := (FibrantF (λ w, P w.1 w.2.1 w.2.2)) (at level 10) : Fib_scope.
@@ -23,15 +24,18 @@ Global Existing Instance TypeF_F.
 
 Axiom FibrantF_forall : ∀ {A: Type} {B: A -> Type} {C: ∀ x, B x -> Type},
     FibrantF B -> FibrantF2 C -> FibrantF (λ x, ∀ y, C x y).
+Global Existing Instance FibrantF_forall.
 
 Axiom FibrantF_sigma : ∀ {A: Type} {B: A -> Type} {C: ∀ x, B x -> Type},
     FibrantF B -> FibrantF2 C -> FibrantF (λ x, ∃ y, C x y).
+Global Existing Instance FibrantF_sigma.
 
 Axiom Fibrant_Type : Fibrant Type.
+Global Existing Instance Fibrant_Type.
 
 Axiom FibrantF_compose
   : forall A (B: A -> Type) {FibB: FibrantF B} A' (f: A' -> A), FibrantF (B o f).
-
+Global Existing Instance FibrantF_compose.
 (* Axiom Fibrant_TypeF : Fibrant FType. *)
 
 Instance Fibrant_FibrantF A (B: A -> Type) {FibP: FibrantF B}
@@ -96,7 +100,8 @@ Module Export Paths.
 
   Axiom FibrantF_paths : forall {Δ} (A : Δ -> Type) (t t' : forall x, A x),
       FibrantF A -> FibrantF (fun x => paths (t x) (t' x)).
-
+  Global Existing Instance FibrantF_paths.
+  
   (** The inverse of a path. *)
   Definition inverse {A : Type} {FibA: Fibrant A} {x y : A} (p : paths x y) : paths y x
     := @paths_rec A FibA x (fun y => paths y x) _ idpath y p.
@@ -153,6 +158,7 @@ Defined.
 
 Arguments concat {A FibA x y z} !p !q.
 
+Declare Scope path_scope.
 Delimit Scope path_scope with path.
 Open Scope path_scope.
 

--- a/Overture.v
+++ b/Overture.v
@@ -50,6 +50,7 @@ Defined.
 Open Scope type_scope.
 
 (* ********* Strict Eq ********* *)
+Declare Scope eq_scope.
 Delimit Scope eq_scope with eq.
 Open Scope eq_scope.
 

--- a/Overture.v
+++ b/Overture.v
@@ -1,6 +1,7 @@
 (* -*- coq-prog-args: ("-top" "TTLT.MLTT2.Overture") -*-  *)
 Require Export TLTT.MyTacs.
 
+Global Set Warnings "-notation-overridden".
 
 Notation idmap := (fun x => x).
 

--- a/src/myrewrite.ml
+++ b/src/myrewrite.ml
@@ -20,8 +20,8 @@ let () =
   let open Eqschemes in
   let hack () =
     List.iter (fun (sk, kn) -> hack_replace_const sk kn) [
-      rew_l2r_scheme_kind, KerName.make2 mp' (Label.make "paths_rec'");
-      rew_r2l_scheme_kind, KerName.make2 mp' (Label.make "paths_rec");
+      rew_l2r_scheme_kind, KerName.make mp' (Label.make "paths_rec'");
+      rew_r2l_scheme_kind, KerName.make mp' (Label.make "paths_rec");
     ]
   in
   Mltop.declare_cache_obj hack "myrewrite"

--- a/src/myrewrite2.ml
+++ b/src/myrewrite2.ml
@@ -20,8 +20,8 @@ let () =
   let open Eqschemes in
   let hack () =
     List.iter (fun (sk, kn) -> hack_replace_const sk kn) [
-      rew_l2r_scheme_kind, KerName.make2 mp' (Label.make "paths_rec'");
-      rew_r2l_scheme_kind, KerName.make2 mp' (Label.make "paths_rec");
+      rew_l2r_scheme_kind, KerName.make mp' (Label.make "paths_rec'");
+      rew_r2l_scheme_kind, KerName.make mp' (Label.make "paths_rec");
     ]
   in
   Mltop.declare_cache_obj hack "myrewrite2"


### PR DESCRIPTION
Here are a few tweaks that I did to get the repo to compile.

* I've suppressed the notation-overridden warnings to reduce noise whilst using make. This commit can be dropped if needed.
* I've tweaked the plugins to use `KerName.make` instead of `KerName.make2` as that didn't exist anymore.
* Axioms are no longer declared as instances, so I have gone ahead and added `Existing Instance` to each axiom that needed it. There is a flag in coq to re-enable this behaviour but it is deprecated.
* I've also added `.vos` `.vok` and `.d` files to `.gitignore` since these are getting generated by newer versions of coq.